### PR TITLE
Fix/issue 53 factoids trigger

### DIFF
--- a/src/plugins/factoids.ts
+++ b/src/plugins/factoids.ts
@@ -127,10 +127,10 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
     patternRegistry.registerPattern(/^!factoid:\s*list$/i, 'factoids', 1);
     patternRegistry.registerPattern(/^forget\s+(.+)$/i, 'factoids', 1);
     patternRegistry.registerPattern(/^(YES|NO)$/i, 'factoids', 0.5); // Lower priority for YES/NO
-    patternRegistry.registerPattern(/^(\S+)[!?]$/, 'factoids', 1); // Only match when immediately followed by ? or !
+    patternRegistry.registerPattern(/^(.+\S)[!?]$/, 'factoids', 1); // Allow spaces in factoid names but ensure punctuation directly follows
     
     // Also register patterns that can be handled in direct mentions (app_mention events)
-    patternRegistry.registerPattern(/^(\S+)[!?]$/, 'factoids:app_mention', 1); // Only match when immediately followed by ? or !
+    patternRegistry.registerPattern(/^(.+\S)[!?]$/, 'factoids:app_mention', 1); // Allow spaces in factoid names but ensure punctuation directly follows
 
     // Add new list command
     app.message(/^!factoid:\s*list$/i, async ({ message, say, context }) => {
@@ -165,7 +165,7 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
     });
 
     // Query a factoid - triggered by a pattern followed by ? or !
-    app.message(/^(\S+)[!?]$/, async ({ message, context, client, say }) => {
+    app.message(/^(.+\S)[!?]$/, async ({ message, context, client, say }) => {
         if (!context?.matches?.[1]) return;
 
         const msg = message as GenericMessageEvent;
@@ -270,7 +270,7 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
         const text = decodeHtmlEntities(mention.text.replace(/<@[^>]+>\s*/, '').trim());
 
         // Handle query factoid pattern first (patterns followed by ? or !)
-        const queryMatch = text.match(/^(\S+)[!?]$/);
+        const queryMatch = text.match(/^(.+\S)[!?]$/);
         if (queryMatch) {
             const rawQuery = queryMatch[1].trim();
             // Handle quotes in the query by optionally removing them


### PR DESCRIPTION
This pull request includes changes to the `src/plugins/factoids.ts` file to improve the handling of factoid patterns. The main focus is to allow spaces in factoid names while ensuring punctuation directly follows the names.

Pattern handling improvements:

* Updated the pattern for factoid names to allow spaces but ensure punctuation directly follows in the `patternRegistry.registerPattern` method. [[1]](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acL130-R133) [[2]](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acL168-R168)
* Applied the same update to the pattern for factoid names when handled in direct mentions.
* Modified the query factoid pattern to match the new pattern rules.