### PR TITLE
76 factoid previews

### DIFF
--- a/src/plugins/factoids.ts
+++ b/src/plugins/factoids.ts
@@ -155,13 +155,22 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
             // Modified to include preview indicators
             const sortedKeys = keys.sort().map(key => {
                 const fact = factoids.data[key];
-                // Add eye emoji only for factoids that will display previews
-                const previewIndicator = fact.previewLinks !== false ? " 👁️" : "";
+                
+                // Only show eye emoji if:
+                // 1. Preview is enabled (previewLinks !== false)
+                // 2. The factoid actually contains URLs that could be unfurled
+                const containsUrls = fact.value.some(v => {
+                    // Simple URL detection regex
+                    return /https?:\/\/[^\s]+/.test(v);
+                });
+                
+                // Add eye emoji only for factoids that will display previews AND contain URLs
+                const previewIndicator = (fact.previewLinks !== false && containsUrls) ? " 👁️" : "";
                 return fact.key + previewIndicator;
             });
 
             await say({
-                text: `Available factoids: ${sortedKeys.join(', ')}`,
+                text: `Available factoids: \n• 👁️ _indicates links with previews enabled_ \n${sortedKeys.join(', ')}`,
                 thread_ts: msg.thread_ts || msg.ts // Always reply in a thread
             });
         } catch (error) {

--- a/src/plugins/help.ts
+++ b/src/plugins/help.ts
@@ -23,7 +23,7 @@ const helpText: HelpText = {
             { pattern: '@bot X is Y | preview', description: 'Set with link previews enabled (default)' },
             { pattern: '@bot X is Y | nopreview', description: 'Set with link previews disabled' },
             { pattern: '@bot forget X', description: 'Delete a factoid' },
-            { pattern: '!factoid: list', description: 'List all factoids (👁️ shows previews enabled)' }
+            { pattern: '!factoid: list', description: 'List all factoids (👁️ indicates links with previews enabled)' }
         ]
     },
     karma: {


### PR DESCRIPTION
This pull request enhances the `factoids` plugin by introducing a new feature to manage link previews for factoids. Users can now enable or disable link previews when creating or managing factoids, and factoids with previews enabled are visually marked in the list. The changes also include updates to the help documentation to reflect this new functionality.

### New Feature: Link Previews for Factoids
* Added an optional `previewLinks` field to the `Fact` interface to control whether link previews are shown. Defaults to `true` unless explicitly set to `false`. (`src/plugins/factoids.ts`, [src/plugins/factoids.tsR15](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acR15))
* Modified the factoid creation logic to parse a `| preview` or `| nopreview` suffix in the value to set the `previewLinks` field accordingly. (`src/plugins/factoids.ts`, [src/plugins/factoids.tsR550-R571](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acR550-R571))
* Updated the `append` logic to preserve the existing `previewLinks` setting unless explicitly overridden. (`src/plugins/factoids.ts`, [src/plugins/factoids.tsR664-R673](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acR664-R673))

### User Experience Enhancements
* Updated the factoid listing logic to display an eye emoji ("👁️") next to factoids with link previews enabled and containing URLs. (`src/plugins/factoids.ts`, [src/plugins/factoids.tsL154-R173](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acL154-R173))
* Adjusted the Slack message output to include `unfurl_links` and `unfurl_media` settings based on the `previewLinks` field. (`src/plugins/factoids.ts`, [[1]](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acR240-R241) [[2]](diffhunk://#diff-16a6d53672dd5e53ab7bf4ffa1dae310d5e696ecda0d5dccf5982a53d22b35acR367-R368)

### Documentation Updates
* Added examples for enabling or disabling link previews to the help text, and clarified the meaning of the eye emoji in the factoid list. (`src/plugins/help.ts`, [src/plugins/help.tsR23-R26](diffhunk://#diff-1f3e5133aab86ee2fbe6c0e9f9f487ce79c56946eec7b4dc7f9fa289ff245ae8R23-R26))

Resolves #76 