### PR TITLE
update what permissions we need:wq

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Examples:
 6. Grant these **minimum required** repository permissions:
    - ✅ **Issues: Write** (to create issues from Slack prompts)
    - ✅ **Metadata: Read** (to access basic repository information)
+   - ✅ **Contents: Write** (to read/write repository contents)
 7. Click "Generate token" and copy the token (starts with `github_pat_`)
 8. Add to your `.env` file: `GITHUB_TOKEN=github_pat_your_token_here`
 


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change adds a new required repository permission, **Contents: Write**, to the list of minimum required permissions for generating a GitHub token.