### PR TITLE
fix: skip TruffleHog scan on main branch pushes to avoid BASE/HEAD co…

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Scan for secrets
         uses: trufflesecurity/trufflehog@main
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         with:
           path: ./
           base: main


### PR DESCRIPTION
…nflict

- Add conditional to only run TruffleHog on PRs, scheduled runs, and non-main pushes
- Prevents "BASE and HEAD commits are the same" error when pushing to main
- Maintains secret scanning for pull requests and scheduled audits

🤖 Generated with [Claude Code](https://claude.ai/code)