### PR TITLE
fix: correct TruffleHog Docker tag format

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,13 +54,13 @@ jobs:
         if: github.event_name == 'push' && github.event.before == '0000000000000000000000000000000000000000'
         run: |
           echo "🔍 Running full scan for initial branch push..."
-          docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:v3.90.6 filesystem /pwd --only-verified --fail
+          docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:3.90.6 filesystem /pwd --only-verified --fail
 
       - name: Full repository scan (Scheduled)
         if: github.event_name == 'schedule'
         run: |
           echo "🔍 Running full repository scan for secrets..."
-          docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:v3.90.6 filesystem /pwd --only-verified --fail
+          docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:3.90.6 filesystem /pwd --only-verified --fail
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
- Remove 'v' prefix from version tag (3.90.6 instead of v3.90.6)
- Docker Hub uses numeric version without 'v' prefix
- Fixes manifest not found error in CI

🤖 Generated with [Claude Code](https://claude.ai/code)