### PR TITLE
feat(factoids): add keyword search command

### DIFF
--- a/src/plugins/__tests__/factoids.test.ts
+++ b/src/plugins/__tests__/factoids.test.ts
@@ -96,6 +96,36 @@ describe('Factoids Plugin', () => {
         });
     });
     
+    describe('Search Command Pattern', () => {
+        const searchPattern = /^!factoid:\s*search\s+(.+)$/i;
+
+        it('should match "!factoid: search journal"', () => {
+            expect(searchPattern.test('!factoid: search journal')).toBe(true);
+        });
+
+        it('should match "!factoid: search foo bar"', () => {
+            expect(searchPattern.test('!factoid: search foo bar')).toBe(true);
+        });
+
+        it('should match case-insensitively', () => {
+            expect(searchPattern.test('!Factoid: Search Journal')).toBe(true);
+        });
+
+        it('should NOT match without a keyword', () => {
+            expect(searchPattern.test('!factoid: search')).toBe(false);
+        });
+
+        it('should capture the keyword', () => {
+            const match = '!factoid: search journal'.match(searchPattern);
+            expect(match?.[1]).toBe('journal');
+        });
+
+        it('should capture multi-word keywords', () => {
+            const match = '!factoid: search project journal'.match(searchPattern);
+            expect(match?.[1]).toBe('project journal');
+        });
+    });
+
     describe('Pattern Matching', () => {
         // Helper function to process a message and determine if it triggers a factoid
         const shouldTriggerFactoid = (text: string): boolean => {

--- a/src/plugins/__tests__/factoids.test.ts
+++ b/src/plugins/__tests__/factoids.test.ts
@@ -124,6 +124,19 @@ describe('Factoids Plugin', () => {
             const match = '!factoid: search project journal'.match(searchPattern);
             expect(match?.[1]).toBe('project journal');
         });
+
+        it('should register the search pattern with the registry', () => {
+            expect(patternRegistry.registerPattern).toHaveBeenCalledWith(
+                /^!factoid:\s*search\s+(.+)$/i, 'factoids', 1
+            );
+        });
+
+        it('should register a message handler for the search pattern', () => {
+            const searchCall = (app.message as ReturnType<typeof vi.fn>).mock.calls.find(
+                (args: unknown[]) => args[0] instanceof RegExp && args[0].source.includes('search')
+            );
+            expect(searchCall).toBeDefined();
+        });
     });
 
     describe('Pattern Matching', () => {

--- a/src/plugins/factoids.ts
+++ b/src/plugins/factoids.ts
@@ -1254,14 +1254,23 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
         const msg = message as GenericMessageEvent;
         const team = context.teamId || 'default';
         try {
-            const match = msg.text?.match(/^!factoid:\s*search\s+(.+)$/i);
-            if (!match) return;
-            const keyword = match[1].trim().toLowerCase();
+            const keywordMatch = context.matches?.[1];
+            if (!keywordMatch) return;
+            const keyword = keywordMatch.trim().toLowerCase();
+
+            if (!keyword) {
+                await say({
+                    text: 'Please provide a keyword to search for.',
+                    thread_ts: msg.thread_ts || msg.ts
+                });
+                return;
+            }
 
             const factoids = await loadFacts(team);
-            const keys = Object.keys(factoids.data);
-            const matches = keys
-                .filter(key => key.toLowerCase().includes(keyword))
+            const MAX_SEARCH_RESULTS = 10;
+            const matches = Object.values(factoids.data)
+                .map(fact => fact.key)
+                .filter((key): key is string => Boolean(key) && key.toLowerCase().includes(keyword))
                 .sort();
 
             if (matches.length === 0) {
@@ -1272,13 +1281,20 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
                 return;
             }
 
+            const displayMatches = matches.slice(0, MAX_SEARCH_RESULTS);
+            const remaining = matches.length - displayMatches.length;
+
             let list: string;
-            if (matches.length === 1) {
-                list = matches[0];
-            } else if (matches.length === 2) {
-                list = `${matches[0]} and ${matches[1]}`;
+            if (displayMatches.length === 1) {
+                list = displayMatches[0];
+            } else if (displayMatches.length === 2) {
+                list = `${displayMatches[0]} and ${displayMatches[1]}`;
             } else {
-                list = `${matches.slice(0, -1).join(', ')}, and ${matches[matches.length - 1]}`;
+                list = `${displayMatches.slice(0, -1).join(', ')}, and ${displayMatches[displayMatches.length - 1]}`;
+            }
+
+            if (remaining > 0) {
+                list = `${list} (and ${remaining} more)`;
             }
 
             await say({
@@ -1288,7 +1304,7 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
         } catch (error) {
             console.error('Error searching factoids:', error);
             await say({
-                text: `Error searching factoids: ${error}`,
+                text: 'Error searching factoids.',
                 thread_ts: msg.thread_ts || msg.ts
             });
         }

--- a/src/plugins/factoids.ts
+++ b/src/plugins/factoids.ts
@@ -1267,7 +1267,6 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
             }
 
             const factoids = await loadFacts(team);
-            const MAX_SEARCH_RESULTS = 10;
             const matches = Object.values(factoids.data)
                 .map(fact => fact.key)
                 .filter((key): key is string => Boolean(key) && key.toLowerCase().includes(keyword))
@@ -1281,20 +1280,13 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
                 return;
             }
 
-            const displayMatches = matches.slice(0, MAX_SEARCH_RESULTS);
-            const remaining = matches.length - displayMatches.length;
-
             let list: string;
-            if (displayMatches.length === 1) {
-                list = displayMatches[0];
-            } else if (displayMatches.length === 2) {
-                list = `${displayMatches[0]} and ${displayMatches[1]}`;
+            if (matches.length === 1) {
+                list = matches[0];
+            } else if (matches.length === 2) {
+                list = `${matches[0]} and ${matches[1]}`;
             } else {
-                list = `${displayMatches.slice(0, -1).join(', ')}, and ${displayMatches[displayMatches.length - 1]}`;
-            }
-
-            if (remaining > 0) {
-                list = `${list} (and ${remaining} more)`;
+                list = `${matches.slice(0, -1).join(', ')}, and ${matches[matches.length - 1]}`;
             }
 
             await say({

--- a/src/plugins/factoids.ts
+++ b/src/plugins/factoids.ts
@@ -202,6 +202,7 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
     patternRegistry.registerPattern(/^!factoid:\s*backup$/i, 'factoids', 1); // Add new backup command
     patternRegistry.registerPattern(/^!factoid:\s*restore\s+(.+)$/i, 'factoids', 1); // Add new restore command
     patternRegistry.registerPattern(/^!factoid:\s*backups$/i, 'factoids', 1); // Add command to list backups
+    patternRegistry.registerPattern(/^!factoid:\s*search\s+(.+)$/i, 'factoids', 1); // Search factoids by keyword
     // Two separate patterns for factoids - both lower priority than other commands
     patternRegistry.registerPattern(/^.+[!?]$/, 'factoids', 0.25); // Any text ending with ? or !
     
@@ -1245,6 +1246,51 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
                 replace_original: false
             });
             pendingRestoreRequests.delete(userId);
+        }
+    });
+
+    // Search factoids by keyword
+    app.message(/^!factoid:\s*search\s+(.+)$/i, async ({ message, say, context }) => {
+        const msg = message as GenericMessageEvent;
+        const team = context.teamId || 'default';
+        try {
+            const match = msg.text?.match(/^!factoid:\s*search\s+(.+)$/i);
+            if (!match) return;
+            const keyword = match[1].trim().toLowerCase();
+
+            const factoids = await loadFacts(team);
+            const keys = Object.keys(factoids.data);
+            const matches = keys
+                .filter(key => key.toLowerCase().includes(keyword))
+                .sort();
+
+            if (matches.length === 0) {
+                await say({
+                    text: `No factoids found matching '${keyword}'`,
+                    thread_ts: msg.thread_ts || msg.ts
+                });
+                return;
+            }
+
+            let list: string;
+            if (matches.length === 1) {
+                list = matches[0];
+            } else if (matches.length === 2) {
+                list = `${matches[0]} and ${matches[1]}`;
+            } else {
+                list = `${matches.slice(0, -1).join(', ')}, and ${matches[matches.length - 1]}`;
+            }
+
+            await say({
+                text: `Found: ${list}`,
+                thread_ts: msg.thread_ts || msg.ts
+            });
+        } catch (error) {
+            console.error('Error searching factoids:', error);
+            await say({
+                text: `Error searching factoids: ${error}`,
+                thread_ts: msg.thread_ts || msg.ts
+            });
         }
     });
 

--- a/src/plugins/help.ts
+++ b/src/plugins/help.ts
@@ -36,7 +36,8 @@ const helpText: HelpText = {
             { pattern: '!factoid: cleanup', description: 'Find and remove invalid factoids' },
             { pattern: '!factoid: backup', description: 'Create a backup of all factoids' },
             { pattern: '!factoid: backups', description: 'List available factoid backups' },
-            { pattern: '!factoid: restore FILENAME', description: 'Restore factoids from a backup file' }
+            { pattern: '!factoid: restore FILENAME', description: 'Restore factoids from a backup file' },
+            { pattern: '!factoid: search KEYWORD', description: 'Search factoids by keyword' }
         ]
     },
     karma: {


### PR DESCRIPTION
## Summary

- Adds `!factoid: search KEYWORD` command that searches factoid keys for partial, case-insensitive matches
- Returns a formatted list (e.g., "Found: journal, journals, and project journal")
- Handles no-match case with friendly message
- Responds in thread when applicable

Closes #236

## Test plan

- [x] All 135 existing tests pass
- [x] TypeScript build compiles cleanly
- [x] New tests cover: pattern matching, case insensitivity, keyword capture, multi-word keywords, no-keyword rejection
- [ ] Manual test: DM bot with `!factoid: search <keyword>` and verify results
- [ ] Manual test: verify no-match message appears for nonexistent keywords

🤖 Generated with [Claude Code](https://claude.com/claude-code)