### PR TITLE
[codex] Search factoid values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1388,12 +1388,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/src/plugins/__tests__/factoids.test.ts
+++ b/src/plugins/__tests__/factoids.test.ts
@@ -1,4 +1,5 @@
 import { App } from '@slack/bolt';
+import * as fs from 'fs';
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import factoidsPlugin, { isValidFactoidKey } from '../factoids';
 import patternRegistry from '../../services/pattern-registry';
@@ -99,6 +100,56 @@ describe('Factoids Plugin', () => {
     describe('Search Command Pattern', () => {
         const searchPattern = /^!factoid:\s*search\s+(.+)$/i;
 
+        const getSearchHandler = () => {
+            const searchCall = (app.message as ReturnType<typeof vi.fn>).mock.calls.find(
+                (args: unknown[]) => args[0] instanceof RegExp && args[0].source.includes('search')
+            );
+            expect(searchCall).toBeDefined();
+            return searchCall?.[1] as Function;
+        };
+
+        const mockFactoids = () => {
+            vi.mocked(fs.promises.readFile).mockResolvedValue(JSON.stringify({
+                id: 'T123_factoids',
+                data: {
+                    'joe key': {
+                        key: 'joe key',
+                        be: 'is',
+                        reply: true,
+                        value: ['a value without the term']
+                    },
+                    gif: {
+                        key: 'gif',
+                        be: 'is',
+                        reply: true,
+                        value: ['https://media.giphy.com/joe.gif']
+                    },
+                    unrelated: {
+                        key: 'unrelated',
+                        be: 'is',
+                        reply: true,
+                        value: ['nothing to see here']
+                    }
+                }
+            }));
+        };
+
+        const runSearch = async (keyword: string) => {
+            const say = vi.fn();
+            const handler = getSearchHandler();
+
+            await handler({
+                message: { ts: '123.456' },
+                say,
+                context: {
+                    teamId: 'T123',
+                    matches: [`!factoid: search ${keyword}`, keyword]
+                }
+            });
+
+            return say;
+        };
+
         it('should match "!factoid: search journal"', () => {
             expect(searchPattern.test('!factoid: search journal')).toBe(true);
         });
@@ -136,6 +187,39 @@ describe('Factoids Plugin', () => {
                 (args: unknown[]) => args[0] instanceof RegExp && args[0].source.includes('search')
             );
             expect(searchCall).toBeDefined();
+        });
+
+        it('should find factoids with matching keys', async () => {
+            mockFactoids();
+
+            const say = await runSearch('joe key');
+
+            expect(say).toHaveBeenCalledWith({
+                text: 'Found: joe key',
+                thread_ts: '123.456'
+            });
+        });
+
+        it('should find factoids with matching values', async () => {
+            mockFactoids();
+
+            const say = await runSearch('joe');
+
+            expect(say).toHaveBeenCalledWith({
+                text: 'Found: gif and joe key',
+                thread_ts: '123.456'
+            });
+        });
+
+        it('should report when neither keys nor values match', async () => {
+            mockFactoids();
+
+            const say = await runSearch('missing');
+
+            expect(say).toHaveBeenCalledWith({
+                text: "No factoids found matching 'missing'",
+                thread_ts: '123.456'
+            });
         });
     });
 

--- a/src/plugins/factoids.ts
+++ b/src/plugins/factoids.ts
@@ -1268,8 +1268,13 @@ const factoidsPlugin: Plugin = async (app: App): Promise<void> => {
 
             const factoids = await loadFacts(team);
             const matches = Object.values(factoids.data)
+                .filter(fact => {
+                    const keyMatches = Boolean(fact.key) && fact.key.toLowerCase().includes(keyword);
+                    const valueMatches = (fact.value || []).join(' ').toLowerCase().includes(keyword);
+                    return keyMatches || valueMatches;
+                })
                 .map(fact => fact.key)
-                .filter((key): key is string => Boolean(key) && key.toLowerCase().includes(keyword))
+                .filter((key): key is string => Boolean(key))
                 .sort();
 
             if (matches.length === 0) {


### PR DESCRIPTION
## What changed

- Updated `!factoid: search KEYWORD` to match factoid answer values as well as keys.
- Added handler-level tests for key matches, value matches, and no-match behavior.
- Updated the locked `axios` version to clear the repo's production audit pre-commit hook.

## Why

Users can discover factoids only when the search term appears in the key. If the useful term is in the answer, such as a GIF URL or descriptive text, the Slack command cannot find it.

Fixes #265.

## Validation

- `npm test -- src/plugins/__tests__/factoids.test.ts`
- `npm test`
- `npm run build`
- Pre-commit secret scan, production audit, and test hook passed
